### PR TITLE
refactor(stats): Refactor to use validateReducer util

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "configuration-validator": "1.0.0-beta.9",
+    "configuration-validator": "1.0.0-beta.10",
     "lodash": "4.4.0",
     "path-is-absolute": "1.0.0"
   },

--- a/src/validators/stats/index.js
+++ b/src/validators/stats/index.js
@@ -1,8 +1,9 @@
 import {sortBy, difference, includes} from 'lodash'
 import {friendlyTypeOf} from '../../utils'
+import {validateReducer} from 'configuration-validator'
 
-const EXIT_EARLY = 'EXIT_EARLY'
-const CONTINUE = 'CONTINUE'
+const {EXIT_EARLY, CONTINUE} = validateReducer
+
 const validProperties = getValidProperties()
 const validKeys = validProperties.map(({key}) => key)
 const validStringValues = sortBy([
@@ -21,16 +22,7 @@ export {validKeysJoined, validStringValuesJoined, validDataTypesJoined, validate
 
 
 function validateStats(val) {
-  const result = validators.reduce((res, validator) => {
-    if (res !== CONTINUE) {
-      return res
-    }
-    return validator(val)
-  }, CONTINUE)
-
-  if (result !== CONTINUE && result !== EXIT_EARLY) {
-    return result
-  }
+  return validateReducer(validators, val)
 }
 
 function validateDataType(val) {


### PR DESCRIPTION
I pulled out the reducer logic into `configuration-validator`

This build will fail because `configuration-validator@1.0.0-beta.10` hasn't been released yet. It's waiting on https://github.com/kentcdodds/configuration-validator/pull/17 and https://github.com/kentcdodds/configuration-validator/pull/16
