### PR TITLE
chore(babel-build): ignore test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "commit": "git-cz",
     "prebuild": "rimraf dist",
     "validate": "npm-run-all --parallel lint cover build test:configs --sequential check-coverage",
-    "build": "babel -d dist src",
+    "build": "babel --ignore src/**/*.test.js -d dist src",
     "check-coverage": "nyc check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "report-coverage": "cat ./coverage/lcov.info | node_modules/.bin/codecov",
     "lint": "eslint .",
@@ -74,7 +74,7 @@
   },
   "nyc": {
     "exclude": [
-      "**/*.test.js",
+      "**/*.test.*",
       "tests/fixtures.js"
     ]
   },


### PR DESCRIPTION
ignore test files from being transpiled
